### PR TITLE
[🚀 Chore] proxy 백엔드 주소 수정

### DIFF
--- a/src/setupProxy.ts
+++ b/src/setupProxy.ts
@@ -3,7 +3,7 @@ const { createProxyMiddleware } = require("http-proxy-middleware")
 module.exports = (app) => {
   app.use(
     createProxyMiddleware("/api", {
-      target: "http://43.200.20.25:8080",
+      target: "http://43.202.36.104:8080",
       changeOrigin: true,
       pathRewrite: { "^/api": "" },
     }),

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "rewrites": [
     {
       "source": "/api/:path*",
-      "destination": "http://43.200.20.25:8080/:path*"
+      "destination": "http://43.202.36.104:8080/:path*"
     }
   ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   server: {
     proxy: {
       "/api": {
-        target: "http://43.200.20.25:8080",
+        target: "http://43.202.36.104:8080",
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ""),
       },


### PR DESCRIPTION
# Chore: proxy 백엔드 주소 변경

기존 퍼블릭 IPv4 주소를 새로 배포된 `43.202.36.104`로 변경