### PR TITLE
[fix 🔨] vercel 404 이슈 해결

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "source": "/api/:path*",
       "destination": "http://43.202.36.104:8080/:path*"
+    },
+    {
+      "source": "/:path*",
+      "destination": "/"
     }
   ]
 }


### PR DESCRIPTION
## fix : vercel 새로고침 시 404 이슈 해결을 위한 vercel.json 수정

👉 SPA(Single Page Application)에서 흔히 발생하는 이슈
: React가 클라이언트 사이드 라우팅을 사용하므로 새로고침 시에 해당 경로에 대한 정보를 서버가 가지고 있지 못해 404 오류를 반환
- - -
∴ vercel이 모든 경로에 대해 react 시작점으로 진입할 수 있도록 vercel.json에  rewrites 설정을 추가 
`전체 경로를 "/"(시작점)으로 redirect → 라우터로 기존 새로고침 시도한 경로로 다시 렌더링`

참고로, 첫 번째 rewrite는 "/api" 경로로 들어오는 요청을 외부의 백엔드 서버로 proxy
