### PR TITLE
[Chore 🚀] clone 삭제, fetch-depth 0에서 1로 수정

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Copy changes to deploy Repo
         run: |
-          rsync -av --delete --exclude='.git' --exclude='node_modules/' . clone/
+          rsync -av --delete --exclude='.git' --exclude='node_modules/' --progress . clone/
           ls -al clone/
 
       - name: Commit and Push changes to deploy repo main branch

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,12 +16,12 @@ jobs:
 
       - name: Copy changes to deploy Repo
         run: |
-          rsync -av --delete --exclude='.git' --exclude='node_modules/' . main/
-          ls -al main/
+          rsync -av --delete --exclude='.git' --exclude='node_modules/' . clone/
+          ls -al clone/
 
       - name: Commit and Push changes to deploy repo main branch
         run: |
-          cd main
+          cd clone
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
           git status 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Push to forked Repo
+name: Push to deploy Repo
 
 on:
   push:
@@ -9,30 +9,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Frontend repo
+      - name: Checkout current repo
         uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
-      - name: Clone main Repo
+      - name: Copy changes to deploy Repo
         run: |
-          git clone https://github.com/staccato20/FitnessMate-FE-Deploy main
+          rsync -av --delete --exclude='.git' --exclude='node_modules/' . main/
+          ls -al main/
 
-      - name: Remove all files in main Repo
-        run: |
-          rm -rf main/*  # 기존 파일 모두 삭제
-
-      - name: Copy changes to main Repo
-        run: |
-          rsync -av --delete --exclude='.git' --exclude='node_modules/' --exclude='main/' . main/
-          ls -al main/  # 복사된 파일 목록 확인
-
-      - name: Commit and Push changes to main repo main branch
+      - name: Commit and Push changes to deploy repo main branch
         run: |
           cd main
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
-          git status  # 변경된 파일 목록 확인
-          git add -A  # 모든 변경 사항 추가
+          git status 
+          git add -A  
           git commit -m "Update from Frontend repo by ${{ github.actor }}" || echo "No changes to commit"
           git push https://x-access-token:${{ secrets.FITMATE_STACCATO20 }}@github.com/staccato20/FitnessMate-FE-Deploy.git main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,4 +27,6 @@ jobs:
           git status 
           git add -A  
           git commit -m "Update from Frontend repo by ${{ github.actor }}" || echo "No changes to commit"
-          git push https://x-access-token:${{ secrets.FITMATE_STACCATO20 }}@github.com/staccato20/FitnessMate-FE-Deploy.git main
+          git push origin main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- #이슈번호, #이슈번호-->
#271 

## 💡 핵심적으로 구현된 사항

- `checkout` 과 `git clone` 이 혼재
  - CI/CD 환경에서는 checkout을 통해 특정 또는 모든 커밋 내역을 가져오므로 `git clone`이 불필요함.
- 클론 후 파일 삭제
  - 복사하고 바로 파일 삭제하는 것은 무의미하므로 파일 삭제 액션 제거
- `checkout` 모든 커밋 이력을 가져옴
    - 어차피 pull request로 여러 커밋이 하나의 커밋으로 합쳐져 최신 변경 커밋만 동기화시켜야 하므로 fetch-depth의 값을 0에서 1로 변경(모든 커밋 이력 받아오기 -> 최신 커밋 이력 하나만 받아오기)
    
- 명확하지 않은 name
   - 레포지토리 이름이 Frontend라서 그대로 Frontend를 쓰기보다는 개발 레포지토리(develop or organization)와 배포 브랜치(deploy or main)로 구분하는것이 좋을듯
   
- exclude 옵션에서 main제거
    - 기본적으로 자기 자신은 제외하고 복사함
    
- push시 url 노출 방지
    - 보안을 위해 workflow 마다 고유하게 생성되는 github token으로 사용자 인증 후 `git push origin main` 으로 push 처리

<!-- 문제를 해결하면서 주요하게 변경된 사항들을 "스크린샷"과 함께 적어 주세요 -->

## ➕ 그 외에 추가적으로 구현된 사항

<!-- 없으면 "없음" 이라고 기재해 주세요 -->
<!-- 주 Task 이외의 작업한 변경 사항  -->

## 🤔 테스트,검증 && 고민 사항

<!-- 배포에서 체크해봐야 할 부분 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->

### 📌 PR Comment 작성 시 Prefix for Reviewers

<!-- * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
* P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
* P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore) -->
