### PR TITLE
Fix/#283/MyRoutine

### DIFF
--- a/src/pages/MyPage/Routine/MyPage.tsx
+++ b/src/pages/MyPage/Routine/MyPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useNavigate } from "react-router-dom"
 
 import Icon from "@components/Icon/Icon"
@@ -37,9 +37,15 @@ const MyPage = () => {
   const [selectedRoutineId, setSelectedRoutineId] = useState<number>(
     myRoutines.length > 0 ? myRoutines[0].routineId : -1,
   )
+  useEffect(() => {
+    if (myRoutines.length > 0 && selectedRoutineId === -1) {
+      setSelectedRoutineId(myRoutines[0].routineId)
+    }
+  }, [myRoutines])
 
-  const { isWorkout } = useGetMyWorkouts(selectedRoutineId)
-
+  const { isWorkout } = useGetMyWorkouts(selectedRoutineId, {
+    enabled: selectedRoutineId > 0, // 유효한 selectedRoutineId만 요청
+  })
   const handleTabChange = (routineId: number) => {
     setSelectedRoutineId(routineId)
   }


### PR DESCRIPTION
## #️⃣연관된 이슈

#283 

## 💡 핵심적으로 구현된 사항

1. `내 운동` 첫 화면에서 첫 번째 루틴의 운동들이 불러와져 있도록 수정
2. `내 운동` 페이지에서 루틴 목록 중 첫 번째가 아닌 루틴을 선택하고 이후 새로고침이 일어났을 때, 첫 번째 루틴으로 되돌아가지 않고 기존에 선택했던 루틴을 그대로 보여주도록 수정

## ➕ 그 외에 추가적으로 구현된 사항

<!-- 없으면 "없음" 이라고 기재해 주세요 -->
<!-- 주 Task 이외의 작업한 변경 사항  -->

## 🤔 테스트,검증 && 고민 사항

핵심 구현사항 2번을 반영하면서 로컬 스토리지를 사용해서 Tab을 조작하는 경우를 위해 공통 컴포넌트인 Tab을 수정하게 되었는데 괜찮은지 확인 부탁드립니다. 혹여 다른 부분에서 이슈를 발생시킨다면 수정하도록 하겠습니다!

### 📌 PR Comment 작성 시 Prefix for Reviewers

<!-- * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
* P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
* P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore) -->
