### PR TITLE
[Fix 🪛] Tab에 width 속성 추가

### DIFF
--- a/src/components/Tab/StyledTab.ts
+++ b/src/components/Tab/StyledTab.ts
@@ -4,8 +4,8 @@ import theme, { fonts } from "@styles/theme"
 
 export const StyledTab = styled.button<{
   $variantStyle: Interpolation<object>
+  $width: Interpolation<object>
 }>`
-  width: 100%;
   border: none;
   display: flex;
   justify-content: center;
@@ -14,7 +14,8 @@ export const StyledTab = styled.button<{
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  ${(p) => p.$variantStyle}
+  width: ${({ $width }) => $width};
+  ${(p) => p.$variantStyle};
 `
 
 export const StyledTabCount = styled.span`

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -12,6 +12,7 @@ interface TabProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   index: number
   count?: number
   isFirstChild?: boolean
+  width?: string
 }
 
 const Tab = ({
@@ -21,6 +22,7 @@ const Tab = ({
   count,
   onClick,
   isFirstChild = false,
+  width = "auto",
   ...props
 }: TabProps) => {
   const { activeTab, switchTab } = useTabs()
@@ -38,6 +40,7 @@ const Tab = ({
     <StyledTab
       onClick={handleTab}
       $variantStyle={variantStyle}
+      $width={width}
       type="button"
       {...props}>
       {children}

--- a/src/components/Tab/getVariant.ts
+++ b/src/components/Tab/getVariant.ts
@@ -15,7 +15,7 @@ export const getVariant = (
         color: ${isSelected ? theme.Netural0 : theme.Netural800};
         background: ${isSelected ? theme.Brand600 : theme.Netural0};
         padding: 1rem 1.4rem;
-        border-radius: 0.2rem;
+        border-radius: 3.4rem;
         ${fonts.b4};
         &:hover {
           background-color: ${!isSelected && theme.Netural200};

--- a/src/pages/Search/StyledSearch.ts
+++ b/src/pages/Search/StyledSearch.ts
@@ -27,7 +27,6 @@ export const NavTab = styled.div`
   z-index: 200;
   position: sticky;
   top: 6.3rem;
-  padding: 0.6rem 3%;
   background: ${theme.Netural0};
 `
 export const NavTabInner = styled.div`
@@ -38,7 +37,6 @@ export const NavTabInner = styled.div`
   gap: 2rem;
   max-width: 111rem;
   margin: 0 auto;
-  padding: 0 2%;
 `
 export const NavTabList = styled.div`
   display: flex;

--- a/src/pages/Search/TabList.tsx
+++ b/src/pages/Search/TabList.tsx
@@ -46,7 +46,7 @@ const TabList = ({
                 <Tabs.Tab
                   key={bodyPartId}
                   index={bodyPartId}
-                  variant="line">
+                  variant="fill">
                   {koreanName}
                 </Tabs.Tab>
               ))}

--- a/src/pages/Signup/BodyFigure/components/Figure/Figure.tsx
+++ b/src/pages/Signup/BodyFigure/components/Figure/Figure.tsx
@@ -14,11 +14,13 @@ const Figure = () => {
           <Tabs.TabList>
             <Tabs.Tab
               variant="line"
+              width="100%"
               index={0}>
               유형으로 선택하기
             </Tabs.Tab>
             <Tabs.Tab
               variant="line"
+              width="100%"
               index={1}>
               직접 입력하기
             </Tabs.Tab>


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- #이슈번호, #이슈번호-->
#319 
## 💡 핵심적으로 구현된 사항
- Tab에 width 컴포넌트로 100% or auto 조정
   
  <img width="754" alt="image" src="https://github.com/user-attachments/assets/b4724d0b-5c5e-4c04-a347-c7070d8ae395" />
    <img width="795" alt="image" src="https://github.com/user-attachments/assets/491d72bd-8eb9-422d-87d3-0dbb2f903a6d" />


<!-- 문제를 해결하면서 주요하게 변경된 사항들을 "스크린샷"과 함께 적어 주세요 -->

## ➕ 그 외에 추가적으로 구현된 사항

<!-- 없으면 "없음" 이라고 기재해 주세요 -->
<!-- 주 Task 이외의 작업한 변경 사항  -->

## 🤔 테스트,검증 && 고민 사항

<!-- 배포에서 체크해봐야 할 부분 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->

### 📌 PR Comment 작성 시 Prefix for Reviewers

<!-- * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
* P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
* P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore) -->
